### PR TITLE
Displaying DB Playlists and Workouts

### DIFF
--- a/app/src/main/java/com/example/sprint0nj/MainActivity.kt
+++ b/app/src/main/java/com/example/sprint0nj/MainActivity.kt
@@ -18,12 +18,32 @@ import androidx.navigation.NavHostController
 import android.widget.Toast // "Toast" is an Android API used to display the short confirmation messages after clicking the buttons
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.DpOffset
-
+import com.example.sprint0nj.data.Classes
+import com.example.sprint0nj.data.FirestoreRepository
+import com.example.sprint0nj.data.Classes.Playlist
+import com.example.sprint0nj.data.Classes.Workout
+import com.example.sprint0nj.data.Classes.WorkoutMods
 
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Hardcoding playlists, will remove soon
+
+//        val firestoreRepository = FirestoreRepository()
+//        val myPlaylist = Playlist(id = "0003",
+//            name = "Leg Day",
+//            workouts = mutableListOf(
+//                WorkoutMods.addWorkout(1, "Squats", null, 8, 3, "Standard squats, focus on depth."),
+//                WorkoutMods.addWorkout(2, "Leg Extensions", null, 12, 3, "Moderate weight leg extensions."),
+//                WorkoutMods.addWorkout(3, "Machine Leg Curls", null, 12, 3, "Standard leg curls."),
+//                WorkoutMods.addWorkout(4, "Deadlifts", null, 12, 3, "Deadlifts with light to moderate weight.")
+//            )
+//        )
+//        firestoreRepository.postPlaylist(myPlaylist)
+
+
         setContent {
             AppNavHost()  // Show your NavHost here
         }

--- a/app/src/main/java/com/example/sprint0nj/MainActivity.kt
+++ b/app/src/main/java/com/example/sprint0nj/MainActivity.kt
@@ -53,6 +53,9 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun LibraryScreen(navController: NavHostController) {
     val context = LocalContext.current
+
+
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -109,7 +112,7 @@ fun LibraryScreen(navController: NavHostController) {
         playlists.forEach { playlistName ->
             Button(      // Navigate to the WorkoutScreen route
                 onClick = {
-                    navController.navigate("workout")
+                    navController.navigate("workout/${playlistId}")
                           },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/example/sprint0nj/MainActivity.kt
+++ b/app/src/main/java/com/example/sprint0nj/MainActivity.kt
@@ -53,8 +53,12 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun LibraryScreen(navController: NavHostController) {
     val context = LocalContext.current
+    val firestoreRepository = remember {FirestoreRepository()}
+    val playlists = remember { mutableStateOf<List<Pair<String, String>>>(emptyList())}
 
-
+    LaunchedEffect(Unit) {
+        playlists.value = firestoreRepository.fetchPlaylistSummaries()
+    }
 
     Column(
         modifier = Modifier
@@ -66,7 +70,7 @@ fun LibraryScreen(navController: NavHostController) {
         Spacer(modifier = Modifier.height(80.dp))
 
         Text(
-            text = "My Lists",
+            text = "My Playlists",
             fontSize = 28.sp,
             color = Color.White,
             modifier = Modifier.padding(bottom = 16.dp)
@@ -107,12 +111,10 @@ fun LibraryScreen(navController: NavHostController) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        val playlists = listOf("Playlist 1", "Playlist 2", "Playlist 3", "Playlist 4", "Playlist 5")
-
-        playlists.forEach { playlistName ->
+        playlists.value.forEach { (id, name) ->
             Button(      // Navigate to the WorkoutScreen route
                 onClick = {
-                    navController.navigate("workout/${playlistId}")
+                    navController.navigate("workout/$id")
                           },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -121,7 +123,7 @@ fun LibraryScreen(navController: NavHostController) {
                 shape = RoundedCornerShape(8.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = Color.White)
             ) {
-                Text(text = playlistName, fontSize = 16.sp, color = Color.Black)
+                Text(text = name, fontSize = 16.sp, color = Color.Black)
             }
         }
     }

--- a/app/src/main/java/com/example/sprint0nj/NavGraph.kt
+++ b/app/src/main/java/com/example/sprint0nj/NavGraph.kt
@@ -21,7 +21,7 @@ fun AppNavHost(
         composable("library") {
             LibraryScreen(navController) // <-- Library screen
         }
-        composable("workout") { backStackEntry ->
+        composable("workout/{playlistId}") { backStackEntry ->
             val playlistId = backStackEntry.arguments?.getString("playlistId") ?: return@composable
             WorkoutScreen(navController, playlistId) // <-- Workout Screen
         }

--- a/app/src/main/java/com/example/sprint0nj/NavGraph.kt
+++ b/app/src/main/java/com/example/sprint0nj/NavGraph.kt
@@ -21,9 +21,9 @@ fun AppNavHost(
         composable("library") {
             LibraryScreen(navController) // <-- Library screen
         }
-        composable("workout") {
-
-            WorkoutScreen(navController) // <-- Workout Screen
+        composable("workout") { backStackEntry ->
+            val playlistId = backStackEntry.arguments?.getString("playlistId") ?: return@composable
+            WorkoutScreen(navController, playlistId) // <-- Workout Screen
         }
     }
 }

--- a/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
@@ -26,14 +26,14 @@ import com.example.sprint0nj.data.FirestoreRepository
 import com.example.sprint0nj.data.Classes.Playlist
 
 @Composable
-fun WorkoutScreen(navController: NavController) {
+fun WorkoutScreen(navController: NavController, playlistId: String) {
     // This captures the current context which is used in the callbacks for popup
     val context = LocalContext.current
     val firestoreRepository = remember { FirestoreRepository()}
     val scope = rememberCoroutineScope()
     val playlist = remember { mutableStateOf<Playlist?>(null) }
-    LaunchedEffect(Unit) {
-        playlist.value = firestoreRepository.fetchPlaylist("0000")
+    LaunchedEffect(playlistId) {
+        playlist.value = firestoreRepository.fetchPlaylist(playlistId)
     }
 
 
@@ -139,11 +139,4 @@ fun WorkoutScreen(navController: NavController) {
             }
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun WorkoutScreenPreview() {
-    val navController = rememberNavController() // Only works if you have Navigation Compose
-    WorkoutScreen(navController = navController)
 }

--- a/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
@@ -16,12 +16,27 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast // "Toast" is an Android API used to display the short confirmation messages after clicking the buttons
-
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
+import com.example.sprint0nj.data.FirestoreRepository
+import com.example.sprint0nj.data.Classes.Playlist
 
 @Composable
 fun WorkoutScreen(navController: NavController) {
     // This captures the current context which is used in the callbacks for popup
     val context = LocalContext.current
+    val firestoreRepository = remember { FirestoreRepository()}
+    val scope = rememberCoroutineScope()
+    val playlist = remember { mutableStateOf<Playlist?>(null) }
+    LaunchedEffect(Unit) {
+        playlist.value = firestoreRepository.fetchPlaylist("0000")
+    }
+
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -32,6 +47,10 @@ fun WorkoutScreen(navController: NavController) {
         // Shifted this down
         Spacer(modifier = Modifier.height(80.dp))
 
+        if (playlist.value == null) { // Loading if playlist hasnt been fetched yet
+            Text(text = "Loading...", fontSize = 20.sp, color = Color.Black)
+            return@Column
+        }
         // Top row with "Playlist #1" and a plus button on the right
         Row(
             modifier = Modifier
@@ -41,7 +60,7 @@ fun WorkoutScreen(navController: NavController) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Playlist #1",
+                text = playlist.value?.name ?: "Unnamed Playlist",
                 fontSize = 24.sp,
                 color = Color.White
             )
@@ -65,14 +84,9 @@ fun WorkoutScreen(navController: NavController) {
 
         // Example list of workouts with #Reps and #Sets
         // In a real app, you might replace this with dynamic data
-        val workouts = listOf(
-            "Workout A",
-            "Workout B",
-            "Workout C",
-            "Workout D"
-        )
 
-        workouts.forEach { workout ->
+
+        playlist.value?.workouts?.forEach { workout ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -93,12 +107,12 @@ fun WorkoutScreen(navController: NavController) {
                 Column(
                     modifier = Modifier.weight(1f, fill = false).padding(start = 16.dp)
                 ) {
-                    Text(text = workout, fontSize = 16.sp, color = Color.Black)
+                    Text(text = workout.title, fontSize = 16.sp, color = Color.Black)
                     Spacer(modifier = Modifier.height(4.dp))
                     Row {
-                        Text(text = "# Reps:", fontSize = 14.sp, color = Color.Black)
+                        Text(text = "# Reps: ${workout.reps ?: "-"}", fontSize = 14.sp, color = Color.Black)
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "# Sets:", fontSize = 14.sp, color = Color.Black)
+                        Text(text = "# Sets: ${workout.sets ?: "-"}", fontSize = 14.sp, color = Color.Black)
                     }
                 }
             }
@@ -125,4 +139,11 @@ fun WorkoutScreen(navController: NavController) {
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WorkoutScreenPreview() {
+    val navController = rememberNavController() // Only works if you have Navigation Compose
+    WorkoutScreen(navController = navController)
 }

--- a/app/src/main/java/com/example/sprint0nj/data/Classes.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/Classes.kt
@@ -1,8 +1,48 @@
 package com.example.sprint0nj.data
 
 class Classes {
-    data class Playlist(
-        val id : String = "",
-        var name : String = ""
+    data class Workout(
+        val id: Int = 0,
+        var title: String = "",
+        var duration: String? = null,
+        var reps: Int? = null,
+        var sets: Int? = null,
+        var description: String = ""
     )
+
+    data class Playlist(
+        val id: String = "",
+        val name: String = "",
+        var workouts: MutableList<Workout> = mutableListOf()
+    ) {
+        fun addWorkout(workout: Workout) {
+            workouts.add(workout)
+        }
+
+        fun removeWorkout(workout: Workout) {
+            workouts.remove(workout)
+        }
+    }
+    object WorkoutMods { // Using this instead of normal initialization means we can pass these values as parameters
+        fun addWorkout(           // instead of needing to identify each value
+            id: Int,
+            title: String,
+            duration: String? = null,
+            reps: Int? = null,
+            sets: Int? = null,
+            description: String = ""
+        ): Workout {
+            return Classes.Workout(id, title, duration, reps, sets, description)
+        }
+    }
 }
+//    val actWorkout = listOf(
+//        Workout(1, "Full Body HIIT", "30 min", "Intermediate"),
+//        Workout(2, "Yoga Flow", "45 min", "Beginner"),
+//        Workout(3, "Strength Training", "40 min", "Advanced"),
+//        Workout(4, "Cardio Blast", "20 min", "Intermediate"),
+//        Workout(5, "Core Burner", "25 min", "Intermediate"),
+//        Workout(6, "Leg Day", "50 min", "Advanced"),
+//        Workout(7, "Upper Body Strength", "35 min", "Intermediate")
+//    )
+//}

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -42,4 +42,13 @@ class FirestoreRepository {
             emptyList() // Return empty list if there's an error
         }
     }
+    suspend fun fetchPlaylistSummaries(): List<Pair<String, String>> {
+        val playlistNames = playlistsCollection.get().await()
+        return playlistNames.documents.map { document ->
+            val id = document.id
+            val name = document.data?.get("name") as String ?: "Unnamed Playlist"
+            id to name
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -1,6 +1,9 @@
 package com.example.sprint0nj.data
+import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.sprint0nj.data.Classes.Playlist
+import kotlinx.coroutines.tasks.await
+
 
 class FirestoreRepository {
 
@@ -8,30 +11,35 @@ class FirestoreRepository {
     private val playlistsCollection = db.collection("playlists")
 
     // Function to add a playlist to Firestore using provided playlist
-    fun addPlaylist(playlist: Playlist, callback: (Boolean, String?) -> Unit) {
-        playlistsCollection.document(playlist.id).set(playlist) // sets document w/ id "document.id"to value of playlist
+    fun postPlaylist(playlist: Playlist) {
+        playlistsCollection.document(playlist.id.toString()).set(playlist)
             .addOnSuccessListener {
-                callback(true, null) // If successful, continue
+                Log.d("FirestoreRepo", "Playlist '${playlist.name}' successfully posted to Firestore.")
             }
             .addOnFailureListener { exception ->
-                callback(false, exception.message) // If fails, return error message and false
+                Log.d("FirestoreRepo", "Error posting playlist '${playlist.name}': ${exception.message}")
             }
     }
-    fun fetchPlaylist(playlistId: String, callback: (Playlist?) -> Unit){
-        playlistsCollection.document(playlistId).get()
-            .addOnSuccessListener { document ->
-                if(document.exists()){
-                    val fetchedPlaylist = document.toObject(Playlist::class.java)
-                    callback(fetchedPlaylist)
-                }
-                else{
-                    callback(null)
-                }
+    suspend fun fetchPlaylist(playlistId: String): Playlist? {
+        return try {
+            val document = playlistsCollection.document(playlistId).get().await()
+            if (document.exists()) {
+                document.toObject(Playlist::class.java)
+            } else {
+                null
             }
-            .addOnFailureListener {
-                callback(null)
-            }
+        } catch (e: Exception) {
+            null
+        }
     }
 
-
+    // Fetch all playlist IDs from firestore collection
+    suspend fun fetchPlaylistIds(): List<String> {
+        return try {
+            val snapshot = playlistsCollection.get().await()
+            snapshot.documents.mapNotNull { it.id } // Extract document IDs
+        } catch (e: Exception) {
+            emptyList() // Return empty list if there's an error
+        }
+    }
 }


### PR DESCRIPTION
Adding functionality to display name, reps, and sets for each workout upon selecting a playlist. Added a snippet for hardcoding playlists to the database, can be modified and used at any time. Added Marc's header file info to Classes.kt and added fetchPlaylistIds method to FirestoreRepository.kt which lets us get a list of ids from our database collection. Also added fetchPlaylistSummaries which gives the name and id of all playlists. 

TLDR Playlist names and workouts being displayed is now fully functional.