### PR TITLE
Building Library W UserID and Remove Playlist Functionality

### DIFF
--- a/app/src/main/java/com/example/sprint0nj/MainActivity.kt
+++ b/app/src/main/java/com/example/sprint0nj/MainActivity.kt
@@ -22,6 +22,7 @@ import com.example.sprint0nj.data.FirestoreRepository
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import com.example.sprint0nj.MoreOptionsMenu
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,11 +51,37 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun LibraryScreen(navController: NavHostController) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val firestoreRepository = remember { FirestoreRepository() }
     val playlists = remember { mutableStateOf<List<Pair<String, String>>>(emptyList()) }
+    var selectedUserId = "4dz7wUNpKHI0Br9lSg9o" // Will need to be updated to allow for multiple
+                                                // users instead of hardcoding
+
+
+    val localRefreshPlaylists = {
+        if (selectedUserId != null) {
+            scope.launch {
+                val updated = firestoreRepository.fetchPlaylistSummaries(
+                    selectedUserId,
+                    onResult = {updated->
+                        playlists.value = updated
+                    }
+                )
+            }
+        }
+    }
+//    val localFetchPlaylists = {
+//        scope.launch{
+//            val updated = firestoreRepository.fetchPlaylist(playlistId)
+//            playlist.value = updated
+//        }
+//    }
 
     LaunchedEffect(Unit) {
-        playlists.value = firestoreRepository.fetchPlaylistSummaries()
+        firestoreRepository.fetchPlaylistSummaries(userId = selectedUserId){ summaries ->
+            playlists.value = summaries
+        }
+
     }
 
     Column(
@@ -93,6 +120,7 @@ fun LibraryScreen(navController: NavHostController) {
                     // First menu option with the title "Add Playlist"
                     // When clicked, a Toast message is displayed
                     MenuOption("Add Playlist") {
+
                         //Toast.makeText(context, "Add Playlist clicked", Toast.LENGTH_SHORT).show()
                     },
                     // Second menu option with the title "Import Playlist"
@@ -136,8 +164,14 @@ fun LibraryScreen(navController: NavHostController) {
                             Toast.makeText(context, "Share playlist: $name", Toast.LENGTH_SHORT).show()
                         },
                         onRemove = {
-                            // Placeholder: no real removal logic
-                            Toast.makeText(context, "Remove clicked for playlist: $name", Toast.LENGTH_SHORT).show()
+                            firestoreRepository.removePlaylist(
+                                userId = selectedUserId,
+                                playlistId = id,
+                                onSuccess = {
+                                    localRefreshPlaylists()
+                                    Toast.makeText(context, "Remove clicked for playlist: $name", Toast.LENGTH_SHORT).show()
+                                }
+                            )
                         },
                         onEdit = {
                             // Placeholder: no real removal logic

--- a/app/src/main/java/com/example/sprint0nj/PlusButtonPopUp.kt
+++ b/app/src/main/java/com/example/sprint0nj/PlusButtonPopUp.kt
@@ -47,8 +47,12 @@ fun PlaylistNameDialog(
     onDismiss: () -> Unit,      // Called to dismiss the dialog
     onConfirm: (String) -> Unit // Called with the entered playlist name when confirmed
 ) {
+    val context = LocalContext.current
     var playlistName by remember { mutableStateOf(TextFieldValue("")) }
     val firestoreRepository = remember { FirestoreRepository() }
+    var selectedUserId = "4dz7wUNpKHI0Br9lSg9o" // Will need to be updated to allow for multiple
+                                                // users instead of hardcoding
+
     AlertDialog(
         onDismissRequest = { onDismiss() },
         title = { Text("Playlist Name:") },
@@ -70,7 +74,15 @@ fun PlaylistNameDialog(
                         id = UUID.randomUUID().toString(),
                         name = playlistName.text
                     )
-                    firestoreRepository.postPlaylist(playlist)
+                    firestoreRepository.postPlaylist(
+                        playlist = playlist,
+                        userId = selectedUserId,
+                        onSuccess = {
+                            val name = playlist.name
+                            Toast.makeText(context, "Added playlist: $name", Toast.LENGTH_SHORT).show()
+                        }
+                    )
+
                     onConfirm(playlistName.text) // Pass the input to the onConfirm callback
                     onDismiss() // Close the dialog after confirming
                 },
@@ -117,6 +129,9 @@ fun WorkoutSelectionDialog(
     val availableWorkouts = remember { mutableStateOf<List<Workout>>(emptyList())}
     val firestoreRepository = remember {FirestoreRepository()}
 //    val playlist = remember { mutableStateOf<Playlist?>(null) }
+
+    var selectedUserId = "4dz7wUNpKHI0Br9lSg9o" // Will need to be updated to allow for multiple
+                                                // users instead of hardcoding
 
     LaunchedEffect(Unit){
         availableWorkouts.value = firestoreRepository.fetchWorkouts()
@@ -184,7 +199,7 @@ fun WorkoutSelectionDialog(
                         val reps = repsText.toIntOrNull() ?: 0
                         val sets = setsText.toIntOrNull() ?: 0
                         playlist.workouts.add(Workout(UUID.randomUUID().toString(), selectedWorkout, null, reps, sets, ""))
-                        firestoreRepository.postPlaylist(playlist)
+                        firestoreRepository.postPlaylist(playlist = playlist, userId = selectedUserId)
                         onConfirm(WorkoutEntry(selectedWorkout, reps, sets))
                         onDismiss()
                     }

--- a/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
@@ -182,9 +182,6 @@ fun WorkoutScreen(navController: NavController, playlistId: String) {
                             onSuccess = {
                                 localFetchPlaylist()
                                 Toast.makeText(context, "Removed: ${workout.title}", Toast.LENGTH_SHORT).show()
-                            },
-                            onFailure = {
-                                Toast.makeText(context, "Failed to remove: ${workout.title}", Toast.LENGTH_SHORT).show()
                             }
                         )
                     }

--- a/app/src/main/java/com/example/sprint0nj/data/Classes.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/Classes.kt
@@ -28,10 +28,10 @@ class Classes {
 
     // Use firebaseAuth for password and authentification handling, doesnt need to be stored here
     data class User(
-        val userId: String = "", // Will be a UUID on initialization
-        val email: String = "",  // For login
         val displayName: String = "", // Name or something
-        val playlistIds: MutableList<String> = mutableListOf() // List of playlist UUIDs associated with the user
+        val email: String = "",  // For login
+        val playlistIds: MutableList<String> = mutableListOf(), // List of playlist UUIDs associated with the user
+        val userId: String = "" // Will be a UUID on initialization
     )
 
     object WorkoutMods { // Using this instead of normal initialization means we can pass these values as parameters

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -24,6 +24,8 @@ class FirestoreRepository {
                 Log.d("FirestoreRepo", "Error posting playlist '${playlist.name}': ${exception.message}")
             }
     }
+
+    // Fetches playlist by specified id. Used for displaying individual workout pages
     suspend fun fetchPlaylist(playlistId: String): Playlist? {
         return try {
             Log.d("PlaylistId", playlistId)
@@ -37,6 +39,8 @@ class FirestoreRepository {
             null
         }
     }
+
+    // Maps firestore workout document to Classes.Workout object
     suspend fun fetchWorkouts(): List<Workout> {
         val snapshot = db.collection("Workouts").get().await()
         return snapshot.documents.mapNotNull { doc ->
@@ -56,6 +60,8 @@ class FirestoreRepository {
         }
     }
 
+    
+    // Removes given workout from playlist in firestore
     fun removeWorkout(
         playlistId: String,
         workoutId: String,
@@ -67,29 +73,23 @@ class FirestoreRepository {
         playlistRef.get().addOnSuccessListener { document ->
             if (document != null && document.exists()) {
                 val playlist = document.toObject(Playlist::class.java)
-                if (playlist != null) {
-                    val updatedWorkouts = playlist.workouts.filter { it.id != workoutId }
-
-                    playlistRef.update("workouts", updatedWorkouts)
-                        .addOnSuccessListener {
-                            Log.d("Firestore", "Workout removed successfully")
-                            onSuccess()
-                        }
-                        .addOnFailureListener { e ->
-                            Log.e("Firestore", "Failed to update playlist", e)
-                            onFailure(e)
-                        }
-                }
-            } else {
-                onFailure(Exception("Playlist not found"))
+                val updatedWorkouts = playlist.workouts.filter { it.id != workoutId }
+                    
+                playlistRef.update("workouts", updatedWorkouts)
+                    .addOnSuccessListener {
+                        Log.d("Firestore", "Workout removed successfully")
+                        onSuccess()
+                    }
+                    .addOnFailureListener { e ->
+                        Log.e("Firestore", "Failed to update playlist", e)
+                        onFailure(e)
+                    }
             }
-        }.addOnFailureListener { e ->
-            onFailure(e)
         }
     }
 
 
-
+    // Fetching pair of all playlist ids and names, for displaying in library screen
     suspend fun fetchPlaylistSummaries(): List<Pair<String, String>> {
         val playlistNames = playlistsCollection.get().await()
         return playlistNames.documents.map { document ->

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -48,18 +48,6 @@ class FirestoreRepository {
         }
     }
 
-
-
-    // Fetch all playlist IDs from firestore collection
-    suspend fun fetchPlaylistIds(): List<String> {
-        return try {
-            val snapshot = playlistsCollection.get().await()
-            snapshot.documents.mapNotNull { it.id } // Extract document IDs
-        } catch (e: Exception) {
-            emptyList() // Return empty list if there's an error
-        }
-    }
-
     
     // Removes given workout from playlist in firestore
     fun removeWorkout(
@@ -73,7 +61,7 @@ class FirestoreRepository {
         playlistRef.get().addOnSuccessListener { document ->
             if (document != null && document.exists()) {
                 val playlist = document.toObject(Playlist::class.java)
-                val updatedWorkouts = playlist.workouts.filter { it.id != workoutId }
+                val updatedWorkouts = playlist?.workouts?.filter { it.id != workoutId }
                     
                 playlistRef.update("workouts", updatedWorkouts)
                     .addOnSuccessListener {

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -99,25 +99,4 @@ class FirestoreRepository {
         }
     }
 
-    fun getPlaylistsFlow(): Flow<List<Pair<String, String>>> = callbackFlow {
-        val listenerRegistration = db.collection("playlists")
-            .addSnapshotListener { snapshot, error ->
-                if (error != null || snapshot == null) {
-                    close(error ?: Exception("Snapshot is null"))
-                    return@addSnapshotListener
-                }
-
-                val summaries = snapshot.documents.mapNotNull {
-                    val id = it.id
-                    val name = it.getString("name")
-                    if (name != null) id to name else null
-                }
-
-                trySend(summaries)
-            }
-
-        awaitClose { listenerRegistration.remove() }
-    }
-
-
 }

--- a/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/sprint0nj/data/FirestoreRepository.kt
@@ -3,6 +3,8 @@ import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.sprint0nj.data.Classes.Playlist
 import com.example.sprint0nj.data.Classes.Workout
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FieldValue
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -14,21 +16,60 @@ class FirestoreRepository {
     private val db = FirebaseFirestore.getInstance()
     private val playlistsCollection = db.collection("playlists")
 
-    // Function to add a playlist to Firestore using provided playlist
-    fun postPlaylist(playlist: Playlist) {
-        playlistsCollection.document(playlist.id).set(playlist)
-            .addOnSuccessListener {
-                Log.d("FirestoreRepo", "Playlist '${playlist.name}' successfully posted to Firestore.")
+    // Fetching pair of all playlist ids and names, for displaying in library screen
+    fun fetchPlaylistSummaries(userId: String, onResult: (List<Pair<String, String>>) -> Unit) {
+        val userRef = db.collection("users").document(userId)
+
+        userRef.get().addOnSuccessListener { document ->
+            if (document.exists()) {
+                val playlistIds = document.get("playlistIds") as? List<String> ?: emptyList() // If null, empty list
+
+                if (playlistIds.isEmpty()) { // Handling edge cases
+                    onResult(emptyList())
+                    return@addOnSuccessListener
+                }
+
+                db.collection("playlists") // Searching playlists collection with list of user's playlist ids
+                    .whereIn(FieldPath.documentId(), playlistIds)
+                    .get()
+                    .addOnSuccessListener { summaryQuery ->
+                        val summaries = summaryQuery.documents.mapNotNull { doc -> // mapping playlist summaries
+                            val name = doc.getString("name")
+                            if (name != null) doc.id to name else null
+                        }
+                        onResult(summaries)
+                    }
+            } else {
+                onResult(emptyList())  // No user doc = no playlists
             }
-            .addOnFailureListener { exception ->
-                Log.d("FirestoreRepo", "Error posting playlist '${playlist.name}': ${exception.message}")
-            }
+        }.addOnFailureListener {
+            onResult(emptyList())  // In case of any error
+        }
     }
+
+
+
+    // Function to add a playlist to Firestore using provided playlist
+    fun postPlaylist(playlist: Playlist, userId: String,  onSuccess: () -> Unit = {}) {
+        val playlistRef = playlistsCollection.document(playlist.id)
+        val userRef = db.collection("users").document(userId)
+
+        db.runBatch { batch ->
+            // Save the playlist
+            batch.set(playlistRef, playlist)
+
+            // Add this playlist ID to the user's list
+            batch.update(userRef, "playlistIds", FieldValue.arrayUnion(playlist.id))
+
+        }.addOnSuccessListener {
+            onSuccess()
+        }
+    }
+
 
     // Fetches playlist by specified id. Used for displaying individual workout pages
     suspend fun fetchPlaylist(playlistId: String): Playlist? {
         return try {
-            Log.d("PlaylistId", playlistId)
             val document = playlistsCollection.document(playlistId).get().await()
             if (document.exists()) {
                 document.toObject(Playlist::class.java)
@@ -48,43 +89,48 @@ class FirestoreRepository {
         }
     }
 
-    
+
     // Removes given workout from playlist in firestore
     fun removeWorkout(
         playlistId: String,
         workoutId: String,
-        onSuccess: () -> Unit = {},
-        onFailure: (Exception) -> Unit = {}
+        onSuccess: () -> Unit = {} // On success, needs to then update UI and give toast message
     ) {
-        val playlistRef = playlistsCollection.document(playlistId)
+        val playlist = playlistsCollection.document(playlistId)
 
-        playlistRef.get().addOnSuccessListener { document ->
+        playlist.get().addOnSuccessListener { document ->
             if (document != null && document.exists()) {
-                val playlist = document.toObject(Playlist::class.java)
-                val updatedWorkouts = playlist?.workouts?.filter { it.id != workoutId }
+                val playlistObj = document.toObject(Playlist::class.java)
+                val updatedWorkouts = playlistObj?.workouts?.filter { it.id != workoutId }
                     
-                playlistRef.update("workouts", updatedWorkouts)
+                playlist.update("workouts", updatedWorkouts)
                     .addOnSuccessListener {
                         Log.d("Firestore", "Workout removed successfully")
                         onSuccess()
-                    }
-                    .addOnFailureListener { e ->
-                        Log.e("Firestore", "Failed to update playlist", e)
-                        onFailure(e)
                     }
             }
         }
     }
 
 
-    // Fetching pair of all playlist ids and names, for displaying in library screen
-    suspend fun fetchPlaylistSummaries(): List<Pair<String, String>> {
-        val playlistNames = playlistsCollection.get().await()
-        return playlistNames.documents.map { document ->
-            val id = document.id
-            val name = document.data?.get("name") as String ?: "Unnamed Playlist"
-            id to name
+    fun removePlaylist(userId: String, playlistId: String, onSuccess: () -> Unit) {
+
+        // Reference to the playlist document
+        val playlistRef = db.collection("playlists").document(playlistId)
+        val userRef = db.collection("users").document(userId) // Reference to the user document
+
+        db.runBatch { batch ->
+            // Delete the playlist document
+            batch.delete(playlistRef)
+
+            // Update the user's playlist list by removing this playlist ID
+            batch.update(userRef, "playlistIds", FieldValue.arrayRemove(playlistId))
+        }.addOnSuccessListener {
+            onSuccess()
         }
     }
+
+
+
 
 }


### PR DESCRIPTION
Made it so the library screen now loads from fetched list of playlists that are associated with a specific user. User ID is currently hardcoded and will need to be updated once login screen is functional. Switching over to this is causing issues with UI refreshing, so added playlists don't appear until you click out of the page and then back into the page. Gonna work on that.

Also added remove button functionality, so playlists can be removed, and their id will be removed from user association. UI gets refreshed and all is well.