### PR TITLE
UI update for implementing pop up windows for sharing and renaming playlists

### DIFF
--- a/app/src/main/java/com/example/sprint0nj/MoreOptionsMenu.kt
+++ b/app/src/main/java/com/example/sprint0nj/MoreOptionsMenu.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun MoreOptionsMenu(
-    onShare: () -> Unit,
+    onShare: (() -> Unit)? = null,
     onRemove: () -> Unit,
     onEdit: () -> Unit, // New parameter for "Edit" option
     onTutorial: (() -> Unit)? = null  // New optional parameter
@@ -38,21 +38,21 @@ fun MoreOptionsMenu(
         IconButton(onClick = { expanded = true }) {
             Text(text = "...", fontSize = 20.sp , color = Color.White)
         }
-        // The DropdownMenu is displayed when "expanded" is true
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            // Can adjust the offset to control the dropdowns position relative to the button
             offset = DpOffset((-10).dp, (-6).dp)
         ) {
-            // Option to Share
-            DropdownMenuItem(
-                text = { Text("Share") },
-                onClick = {
-                    expanded = false
-                    onShare()
-                }
-            )
+            // Only show the Share option if a callback is provided.
+            if (onShare != null) {
+                DropdownMenuItem(
+                    text = { Text("Share") },
+                    onClick = {
+                        expanded = false
+                        onShare()
+                    }
+                )
+            }
             // Option to Edit
             DropdownMenuItem(
                 text = { Text("Edit") },

--- a/app/src/main/java/com/example/sprint0nj/PlusButtonPopUp.kt
+++ b/app/src/main/java/com/example/sprint0nj/PlusButtonPopUp.kt
@@ -127,9 +127,9 @@ fun WorkoutSelectionDialog(
     onDismiss: () -> Unit,
     onConfirm: (WorkoutEntry) -> Unit
 ) {
-    var selectedWorkout by remember { mutableStateOf("") }
-    var repsText by remember { mutableStateOf("") }
-    var setsText by remember { mutableStateOf("") }
+    var selectedWorkout by remember { mutableStateOf(initialWorkout?.name ?: "") }
+    var repsText by remember { mutableStateOf(initialWorkout?.reps?.toString() ?: "") }
+    var setsText by remember { mutableStateOf(initialWorkout?.sets?.toString() ?: "") }
 
     // State for the Target Muscle button
     var selectedTargetMuscle by remember { mutableStateOf("") }

--- a/app/src/main/java/com/example/sprint0nj/RenamePlaylistDialog.kt
+++ b/app/src/main/java/com/example/sprint0nj/RenamePlaylistDialog.kt
@@ -1,0 +1,75 @@
+package com.example.sprint0nj
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import android.widget.Toast
+
+/**
+ * @param currentName The current playlist name (to pre-populate the text field).
+ * @param onDismiss Callback when the dialog is dismissed.
+ * @param onConfirm Callback with the new name when the user confirms the rename.
+ */
+@Composable
+fun RenamePlaylistDialog(
+    currentName: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit
+) {
+    // text field state with the current playlist name
+    var newName by remember { mutableStateOf(TextFieldValue(currentName)) }
+    val context = LocalContext.current
+
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        title = { Text("Rename Playlist") },
+        text = {
+            Column {
+                Text(text = "Enter new playlist name:", fontSize = 16.sp)
+                Spacer(modifier = Modifier.height(8.dp))
+                BasicTextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.LightGray)
+                        .padding(8.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    if (newName.text.isNotEmpty()) {
+                        onConfirm(newName.text)  // Pass the new name back to the caller
+                        onDismiss()
+                    } else {
+                        Toast.makeText(context, "Playlist name cannot be empty", Toast.LENGTH_SHORT).show()
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Black)
+            ) {
+                Text("Confirm", color = Color.White)
+            }
+        },
+        dismissButton = {
+            Button(
+                onClick = { onDismiss() },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Black)
+            ) {
+                Text("Cancel", color = Color.White)
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/sprint0nj/ShareDialog.kt
+++ b/app/src/main/java/com/example/sprint0nj/ShareDialog.kt
@@ -1,0 +1,137 @@
+package com.example.sprint0nj
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+//import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import android.widget.Toast
+
+@Composable
+fun ShareDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit  // This callback receives the friend's username to share with
+) {
+    val context = LocalContext.current
+
+    // State for manual entry of a friend's username
+    var manualFriendName by remember { mutableStateOf(TextFieldValue("")) }
+
+    // State for controlling the dropdown of friend names
+    var isFriendDropdownExpanded by remember { mutableStateOf(false) }
+
+    // This state holds the friend selected from the dropdown independent of manualFriendName.
+
+    var dropdownSelectedFriend by remember { mutableStateOf("") }
+
+    // Sample list of friend names
+    // Can delete and fetch from Firebase instead
+    val friendList = remember { mutableStateOf(listOf("Andrew", "Nick", "Davis", "Marc")) }
+
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        title = { Text("Share Playlist") },
+        text = {
+            Column {
+                // Manual entry section
+                Text(text = "Enter a username:", fontSize = 16.sp)
+                Spacer(modifier = Modifier.height(4.dp))
+                BasicTextField(
+                    value = manualFriendName,
+                    onValueChange = { manualFriendName = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.LightGray)
+                        .padding(8.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Dropdown section for selecting a friend
+                Text(text = "Or select from your friends:", fontSize = 16.sp)
+                Spacer(modifier = Modifier.height(4.dp))
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Button(
+                        onClick = { isFriendDropdownExpanded = true },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF212121))
+                    ) {
+                        // Display the chosen friend if available
+                        Text(
+                            text = if (dropdownSelectedFriend.isEmpty()) "Select Friend" else dropdownSelectedFriend,
+                            fontSize = 16.sp,
+                            color = Color.White
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = isFriendDropdownExpanded,
+                        onDismissRequest = { isFriendDropdownExpanded = false },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        friendList.value.forEach { friend ->
+                            DropdownMenuItem(
+                                text = { Text(friend) },
+                                onClick = {
+                                    // When a friend is selected, update the selection
+                                    dropdownSelectedFriend = friend
+                                    // Clear the manual text field to indicate that the dropdown selection is used
+                                    manualFriendName = TextFieldValue("")
+                                    isFriendDropdownExpanded = false
+                                }
+                            )
+                        }
+                        // [Firebase Placeholder] Replace the hardcoded friendList with dynamic data here?
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    // Determine which friend username to use:
+                    // If the manual text field is non-empty, use this
+                    // Otherwise, use the friend selected from the dropdown
+                    val friendUsername = if (manualFriendName.text.isNotEmpty()) {
+                        manualFriendName.text
+                    } else {
+                        dropdownSelectedFriend
+                    }
+
+                    if (friendUsername.isNotEmpty()) {
+                        // [Firebase Placeholder] Insert Firebase share logic?
+                        onConfirm(friendUsername)
+                        onDismiss()
+                    } else {
+                        Toast.makeText(
+                            context,
+                            "Please enter or select a friend's username.",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Black)
+            ) {
+                Text("Confirm", color = Color.White)
+            }
+        },
+        dismissButton = {
+            Button(
+                onClick = { onDismiss() },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Black)
+            ) {
+                Text("Cancel", color = Color.White)
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/sprint0nj/WorkoutScreen.kt
@@ -147,7 +147,6 @@ fun WorkoutScreen(navController: NavController, playlistId: String) {
                 .fillMaxWidth()
         ) {
             // Example list of workouts with #Reps and #Sets
-            // In a real app, you might replace this with dynamic data
             items(playlist.value!!.workouts) { workout ->
                 val context = LocalContext.current
 
@@ -191,13 +190,7 @@ fun WorkoutScreen(navController: NavController, playlistId: String) {
                     }
 
                     MoreOptionsMenu(
-                        onShare = {
-                            Toast.makeText(
-                                context,
-                                "Share workout: ${workout.title}",
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        },
+                        onShare = null,
                         onRemove = {
                             firestoreRepository.removeWorkout(
                                 playlistId = playlistId,


### PR DESCRIPTION
Implemented pop up window for sharing playlists. Also added window for editing a playlists name.
Included 2 new files, ShareDialog.kt and RenamePlaylistDialog.kt

They both will still need connecting to firebase. Also, added two new sections to the bottom of MainActivity.kt needing firebase connection also.


Other Changes:

- Removed share option from individual workouts
- Made it so when you edit a workout, it shows the name